### PR TITLE
Fix ConverterNotFoundException in JPA Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ graph TB
 |---|---|
 | **Security Filters** | Mengintercept setiap request. Endpoint `/api/v1/login` ditangani oleh `UsernamePasswordAuthProcessingFilter`. Endpoint lainnya ditangani oleh `JWTAuthProcessingFilter` yang memvalidasi JWT token. |
 | **Controller** | Menerima HTTP request, mendelegasikan ke Service layer, dan mengembalikan HTTP response. |
-| **Service** | Business logic — create, update, delete (soft delete), find, search. |
+| **Service** | **Business Logic & Data Transformation** — Mengelola alur data dan melakukan mapping antara Entity dan DTO menggunakan MapStruct. |
 | **Mapper** | Konversi antara Entity (JPA) dan DTO (response/request) menggunakan MapStruct. |
-| **Repository** | Akses database via Spring Data JPA. Menjalankan query JPQL custom. |
+| **Repository** | **Akses Database** — Mengambil data dari PostgreSQL. **Wajib mengembalikan JPA Entity**. Hindari mengembalikan DTO langsung dari query untuk mencegah `ConverterNotFoundException`. |
 | **Exception Handler** | Menangkap exception global dan mengembalikan response error yang konsisten. |
 
 ---
@@ -331,6 +331,9 @@ Terdapat 3 jenis operasi read:
 | **Find By ID** | `GET /surat-masuk/{ids}/detail` | Cari berdasarkan UUID (`ids`) |
 | **Search** | `GET /surat-masuk/search?value=...&...` | Pencarian teks pada field `asal`, `nomorSurat`, `perihal` (case-insensitive LIKE) |
 
+> [!IMPORTANT]
+> **Repository Return Type**: Semua method repository pada operasi READ wajib mengembalikan `Page<Entity>` atau `Entity`. Konversi ke `DTO` **harus** dilakukan di Service layer sebelum dikirim ke Controller.
+
 ---
 
 ## 8. Model Data (Entity Relationship)
@@ -426,6 +429,11 @@ public interface RegisterSuratService<T> extends CrudGenericService<T> {
     Page<T> findAll(String startDate, String endDate, String jenisSurat, Integer pages, Integer sizes);
     Page<T> findBySearching(String start, String end, String value, String jenisSurat, Integer pages, Integer sizes);
 }
+
+> [!IMPORTANT]
+> **Aturan Mapping Data:**
+> - **Repository Layer** harus selalu mengembalikan objek **Entity**.
+> - **Service Layer** bertanggung jawab mengubah `Page<Entity>` atau `Entity` menjadi `DTO` sebelum dikirim ke Controller.
 ```
 
 ### 9.2 DTO Pattern (Java Record)

--- a/src/main/java/id/go/kejaripalu/bdi/repository/DataPetaRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/DataPetaRepository.java
@@ -1,7 +1,6 @@
 package id.go.kejaripalu.bdi.repository;
 
 import id.go.kejaripalu.bdi.domain.DataPeta;
-import id.go.kejaripalu.bdi.dto.DataPetaDTO;
 import id.go.kejaripalu.bdi.util.BidangDirektorat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +18,7 @@ public interface DataPetaRepository extends JpaRepository<DataPeta, Long> {
         AND p.tanggal BETWEEN :startDate AND :endDate \s
         ORDER BY p.tanggal DESC
         """)
-    Page<DataPetaDTO> findAll(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+    Page<DataPeta> findAll(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 
     @Query("""
         SELECT p FROM DataPeta p WHERE p.deleted=false AND p.bidangDirektorat=:bidangDirektorat \s
@@ -31,7 +30,7 @@ public interface DataPetaRepository extends JpaRepository<DataPeta, Long> {
         AND p.tanggal BETWEEN :startDate AND :endDate \s
         ORDER BY p.tanggal DESC
         """)
-    Page<DataPetaDTO> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
+    Page<DataPeta> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
 
     Optional<DataPeta> findByIdsAndDeletedFalse(String ids);
 

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterArsipRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterArsipRepository.java
@@ -1,22 +1,20 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterArsipDTO;
+import id.go.kejaripalu.bdi.domain.RegisterArsip;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterArsip;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterArsipRepository extends JpaRepository<RegisterArsip, Long> {
 
 	@Query("SELECT r FROM RegisterArsip r WHERE r.deleted=false "
 			+ "AND r.tanggalPenerimaanArsip BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterArsipDTO> findAllArsip(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterArsip> findAllArsip(Date startDate, Date endDate, Pageable pageable);
 
 	@Query("SELECT r FROM RegisterArsip r WHERE r.deleted=false "
 			+ "AND (LOWER(r.diterimaDari) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -25,13 +23,13 @@ public interface RegisterArsipRepository extends JpaRepository<RegisterArsip, Lo
 			+ "OR LOWER(r.nomorSurat) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalPenerimaanArsip BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalPenerimaanArsip DESC, r.jamPenerimaanArsip DESC")
-	Page<RegisterArsipDTO> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
+	Page<RegisterArsip> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
 
 	Optional<RegisterArsip> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterArsip r WHERE r.deleted=false "
 			+ "AND r.tanggalPenerimaanArsip BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalPenerimaanArsip DESC, r.jamPenerimaanArsip DESC")
-	Page<RegisterArsipDTO> findAllArsipToPrint(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterArsip> findAllArsipToPrint(Date startDate, Date endDate, Pageable pageable);
 
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterEkspedisiRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterEkspedisiRepository.java
@@ -1,23 +1,21 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterEkspedisiDTO;
+import id.go.kejaripalu.bdi.domain.RegisterEkspedisi;
+import id.go.kejaripalu.bdi.util.JenisSurat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterEkspedisi;
-import id.go.kejaripalu.bdi.util.JenisSurat;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterEkspedisiRepository extends JpaRepository<RegisterEkspedisi, Long> {
 
 	@Query("SELECT r FROM RegisterEkspedisi r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalTandaTerima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterEkspedisiDTO> findEkspedisiAll(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterEkspedisi> findEkspedisiAll(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 
 	@Query("SELECT r FROM RegisterEkspedisi r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND (LOWER(r.kepada) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -25,13 +23,13 @@ public interface RegisterEkspedisiRepository extends JpaRepository<RegisterEkspe
 			+ "OR LOWER(r.nomorSurat) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalTandaTerima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalTandaTerima DESC, r.jamTandaTerima DESC")
-	Page<RegisterEkspedisiDTO> findEkspedisiBySearching(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterEkspedisi> findEkspedisiBySearching(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
 	
 	Optional<RegisterEkspedisi> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterEkspedisi r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalTandaTerima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalTandaTerima DESC, r.jamTandaTerima DESC")
-	Page<RegisterEkspedisiDTO> findEkspedisiAllToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterEkspedisi> findEkspedisiAllToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKegiatanIntelijenPamstraRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKegiatanIntelijenPamstraRepository.java
@@ -1,22 +1,20 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterKegiatanIntelijenPamstraDTO;
+import id.go.kejaripalu.bdi.domain.RegisterKegiatanIntelijenPamstra;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterKegiatanIntelijenPamstra;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterKegiatanIntelijenPamstraRepository extends JpaRepository<RegisterKegiatanIntelijenPamstra, Long> {
 
 	@Query("SELECT r FROM RegisterKegiatanIntelijenPamstra r WHERE r.deleted=false "
 			+ "AND r.tanggalSuratPermohonan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterKegiatanIntelijenPamstraDTO> findAllKegiatan(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterKegiatanIntelijenPamstra> findAllKegiatan(Date startDate, Date endDate, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterKegiatanIntelijenPamstra r WHERE r.deleted=false "
 			+ "AND (LOWER(r.instansi) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -31,13 +29,13 @@ public interface RegisterKegiatanIntelijenPamstraRepository extends JpaRepositor
 			+ "OR LOWER(r.namaPetugasPelaksana) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalSuratPermohonan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalSuratPermohonan DESC")
-	Page<RegisterKegiatanIntelijenPamstraDTO> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
+	Page<RegisterKegiatanIntelijenPamstra> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
 	
 	Optional<RegisterKegiatanIntelijenPamstra> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterKegiatanIntelijenPamstra r WHERE r.deleted=false "
 			+ "AND r.tanggalSuratPermohonan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id  DESC, r.tanggalSuratPermohonan DESC")
-	Page<RegisterKegiatanIntelijenPamstraDTO> findAllKegiatanToPrint(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterKegiatanIntelijenPamstra> findAllKegiatanToPrint(Date startDate, Date endDate, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKegiatanIntelijenRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKegiatanIntelijenRepository.java
@@ -3,7 +3,6 @@ package id.go.kejaripalu.bdi.repository;
 import java.util.Date;
 import java.util.Optional;
 
-import id.go.kejaripalu.bdi.dto.RegisterKegiatanIntelijenDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,7 +16,7 @@ public interface RegisterKegiatanIntelijenRepository extends JpaRepository<Regis
 	@Query("SELECT r FROM RegisterKegiatanIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterKegiatanIntelijenDTO> findAllKegiatan(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterKegiatanIntelijen> findAllKegiatan(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterKegiatanIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND (LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -26,13 +25,13 @@ public interface RegisterKegiatanIntelijenRepository extends JpaRepository<Regis
 			+ "OR LOWER(r.namaPetugasPelaksana) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggal  DESC")
-	Page<RegisterKegiatanIntelijenDTO> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
+	Page<RegisterKegiatanIntelijen> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
 	
 	Optional<RegisterKegiatanIntelijen> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterKegiatanIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggal DESC")
-	Page<RegisterKegiatanIntelijenDTO> findAllKegiatanToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterKegiatanIntelijen> findAllKegiatanToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKerjaIntelijenRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterKerjaIntelijenRepository.java
@@ -1,35 +1,33 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterKerjaIntelijenDTO;
+import id.go.kejaripalu.bdi.domain.RegisterKerjaIntelijen;
+import id.go.kejaripalu.bdi.util.BidangDirektorat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterKerjaIntelijen;
-import id.go.kejaripalu.bdi.util.BidangDirektorat;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterKerjaIntelijenRepository extends JpaRepository<RegisterKerjaIntelijen, Long> {
 
 	@Query("SELECT r FROM RegisterKerjaIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggalWaktuDiterima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterKerjaIntelijenDTO> findRKIAll(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterKerjaIntelijen> findRKIAll(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterKerjaIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND (LOWER(r.uraianPeristiwaMasalah) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalWaktuDiterima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalWaktuDiterima  DESC, r.jamWaktuDiterima DESC")
-	Page<RegisterKerjaIntelijenDTO> findRKIBySearching(Date startDate, Date endDate, String value, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterKerjaIntelijen> findRKIBySearching(Date startDate, Date endDate, String value, BidangDirektorat bidangDirektorat, Pageable pageable);
 
 	Optional<RegisterKerjaIntelijen> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterKerjaIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggalWaktuDiterima BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalWaktuDiterima  DESC, r.jamWaktuDiterima DESC")
-	Page<RegisterKerjaIntelijenDTO> findRKIAllToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterKerjaIntelijen> findRKIAllToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterOperasiIntelijenRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterOperasiIntelijenRepository.java
@@ -1,23 +1,21 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterOperasiIntelijenDTO;
+import id.go.kejaripalu.bdi.domain.RegisterOperasiIntelijen;
+import id.go.kejaripalu.bdi.util.BidangDirektorat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterOperasiIntelijen;
-import id.go.kejaripalu.bdi.util.BidangDirektorat;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterOperasiIntelijenRepository extends JpaRepository<RegisterOperasiIntelijen, Long> {
 
 	@Query("SELECT r FROM RegisterOperasiIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterOperasiIntelijenDTO> findAllOpsin(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterOperasiIntelijen> findAllOpsin(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterOperasiIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND (LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -25,13 +23,13 @@ public interface RegisterOperasiIntelijenRepository extends JpaRepository<Regist
 			+ "OR LOWER(r.hasilPelaksanaanOperasi) LIKE LOWER(CONCAT('%', :value, '%')) "
 			+ "OR LOWER(r.namaPetugasPelaksana) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate ORDER BY r.tanggal  DESC")
-	Page<RegisterOperasiIntelijenDTO> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
+	Page<RegisterOperasiIntelijen> findBySearching(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, String value, Pageable pageable);
 	
 	Optional<RegisterOperasiIntelijen> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterOperasiIntelijen r WHERE r.deleted=false AND r.bidangDirektorat=:bidangDirektorat "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggal DESC")
-	Page<RegisterOperasiIntelijenDTO> findAllOpsinToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
+	Page<RegisterOperasiIntelijen> findAllOpsinToPrint(Date startDate, Date endDate, BidangDirektorat bidangDirektorat, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterPenkumLuhkumRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterPenkumLuhkumRepository.java
@@ -1,24 +1,22 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterPenkumLuhkumDTO;
+import id.go.kejaripalu.bdi.domain.RegisterPenkumLuhkum;
+import id.go.kejaripalu.bdi.util.JenisKegiatanPenkumLuhkum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterPenkumLuhkum;
-import id.go.kejaripalu.bdi.util.JenisKegiatanPenkumLuhkum;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 public interface RegisterPenkumLuhkumRepository extends JpaRepository<RegisterPenkumLuhkum, Long> {
 
 	@Query("SELECT r FROM RegisterPenkumLuhkum r WHERE r.deleted=false AND r.jenisKegiatan=:jenisKegiatan "
 			+ "AND r.tanggalKegiatan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterPenkumLuhkumDTO> findAllPenkumLuhkum(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, Pageable pageable);
+	Page<RegisterPenkumLuhkum> findAllPenkumLuhkum(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterPenkumLuhkum r WHERE r.deleted=false "
 			+ "AND r.jenisKegiatan=:jenisKegiatan "
@@ -28,14 +26,14 @@ public interface RegisterPenkumLuhkumRepository extends JpaRepository<RegisterPe
 			+ "OR LOWER(r.materi) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalKegiatan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalKegiatan DESC")
-	Page<RegisterPenkumLuhkumDTO> findBySearching(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, String value, Pageable pageable);
+	Page<RegisterPenkumLuhkum> findBySearching(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, String value, Pageable pageable);
 	
 	Optional<RegisterPenkumLuhkum> findByIdsAndDeletedFalse(String ids);
 
 	@Query("SELECT r FROM RegisterPenkumLuhkum r WHERE r.deleted=false AND r.jenisKegiatan=:jenisKegiatan "
 			+ "AND r.tanggalKegiatan BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id  DESC, r.tanggalKegiatan DESC")
-	Page<RegisterPenkumLuhkumDTO> findAllPenkumLuhkumToPrint(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, Pageable pageable);
+	Page<RegisterPenkumLuhkum> findAllPenkumLuhkumToPrint(Date startDate, Date endDate, JenisKegiatanPenkumLuhkum jenisKegiatan, Pageable pageable);
 	
 	@Query("SELECT "
 			+ "(SELECT COUNT(r.program) r FROM RegisterPenkumLuhkum r WHERE r.program = 'BINMATKUM' "

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterProdukIntelijenRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterProdukIntelijenRepository.java
@@ -1,29 +1,27 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterProdukIntelijenDTO;
+import id.go.kejaripalu.bdi.domain.RegisterProdukIntelijen;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterProdukIntelijen;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 public interface RegisterProdukIntelijenRepository extends JpaRepository<RegisterProdukIntelijen, Long> {
 
 	@Query("SELECT r FROM RegisterProdukIntelijen r WHERE r.deleted=false "
 			+ "AND r.tanggalProduk BETWEEN :startDate AND :endDate " + "ORDER BY r.id DESC")
-	Page<RegisterProdukIntelijenDTO> findProdukIntelijenAll(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterProdukIntelijen> findProdukIntelijenAll(Date startDate, Date endDate, Pageable pageable);
 
 	@Query("SELECT r FROM RegisterProdukIntelijen r WHERE r.deleted=false "
 			+ "AND (LOWER(r.nomorProduk) LIKE LOWER(CONCAT('%', :value, '%')) "
 			+ "OR LOWER(r.sektor) LIKE LOWER(CONCAT('%', :value, '%')) "
 			+ "OR LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalProduk BETWEEN :startDate AND :endDate " + "ORDER BY r.tanggalProduk DESC")
-	Page<RegisterProdukIntelijenDTO> findProdukIntelijenBySearching(Date startDate, Date endDate, String value,
+	Page<RegisterProdukIntelijen> findProdukIntelijenBySearching(Date startDate, Date endDate, String value,
 			Pageable pageable);
 
 	Optional<RegisterProdukIntelijen> findByIdsAndDeletedFalse(String ids);
@@ -31,7 +29,7 @@ public interface RegisterProdukIntelijenRepository extends JpaRepository<Registe
 	@Query("SELECT r FROM RegisterProdukIntelijen r WHERE r.deleted=false "
 			+ "AND r.tanggalProduk BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalProduk DESC, r.tanggalProduk DESC")
-	Page<RegisterProdukIntelijenDTO> findProdukIntelijenAllToPrint(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterProdukIntelijen> findProdukIntelijenAllToPrint(Date startDate, Date endDate, Pageable pageable);
 
 	@Query("SELECT "
 			+ "(SELECT COUNT(r.jenisProdukIntelijen) r FROM RegisterProdukIntelijen r WHERE r.jenisProdukIntelijen = 'LAPINHAR' "

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterSuratKeluarRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterSuratKeluarRepository.java
@@ -1,23 +1,21 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterSuratKeluarDTO;
+import id.go.kejaripalu.bdi.domain.RegisterSuratKeluar;
+import id.go.kejaripalu.bdi.util.JenisSurat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterSuratKeluar;
-import id.go.kejaripalu.bdi.util.JenisSurat;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterSuratKeluarRepository extends JpaRepository<RegisterSuratKeluar, Long> {
 	
 	@Query("SELECT r FROM RegisterSuratKeluar r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterSuratKeluarDTO> findSuratKeluar(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratKeluar> findSuratKeluar(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 
 	@Query("SELECT r FROM RegisterSuratKeluar r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND (LOWER(r.nomorSurat) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -25,13 +23,13 @@ public interface RegisterSuratKeluarRepository extends JpaRepository<RegisterSur
 			+ "OR LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalSurat DESC")
-	Page<RegisterSuratKeluarDTO> findSuratKeluarBySearch(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratKeluar> findSuratKeluarBySearch(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
 	
 	Optional<RegisterSuratKeluar> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterSuratKeluar r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalSurat DESC")
-	Page<RegisterSuratKeluarDTO> findSuratKeluarToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratKeluar> findSuratKeluarToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterSuratMasukRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterSuratMasukRepository.java
@@ -1,23 +1,21 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterSuratMasukDTO;
+import id.go.kejaripalu.bdi.domain.RegisterSuratMasuk;
+import id.go.kejaripalu.bdi.util.JenisSurat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterSuratMasuk;
-import id.go.kejaripalu.bdi.util.JenisSurat;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterSuratMasukRepository extends JpaRepository<RegisterSuratMasuk, Long> {
 
 	@Query("SELECT r FROM RegisterSuratMasuk r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalPenerimaanSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterSuratMasukDTO> findSuratMasukAll(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratMasuk> findSuratMasukAll(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 
 	@Query("SELECT r FROM RegisterSuratMasuk r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND (LOWER(r.asal) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -25,14 +23,14 @@ public interface RegisterSuratMasukRepository extends JpaRepository<RegisterSura
 			+ "OR LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggalPenerimaanSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggalPenerimaanSurat DESC, r.jamPenerimaanSurat DESC")
-	Page<RegisterSuratMasukDTO> findSuratMasukBySearching(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratMasuk> findSuratMasukBySearching(Date startDate, Date endDate, String value, JenisSurat jenisSurat, Pageable pageable);
 	
 	Optional<RegisterSuratMasuk> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterSuratMasuk r WHERE r.deleted=false AND r.jenisSurat=:jenisSurat "
 			+ "AND r.tanggalPenerimaanSurat BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggalPenerimaanSurat DESC, r.jamPenerimaanSurat DESC")
-	Page<RegisterSuratMasukDTO> findSuratMasukAllToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
+	Page<RegisterSuratMasuk> findSuratMasukAllToPrint(Date startDate, Date endDate, JenisSurat jenisSurat, Pageable pageable);
 
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterTamuPPHPPMRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterTamuPPHPPMRepository.java
@@ -1,23 +1,21 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterTamuPPHPPMDTO;
+import id.go.kejaripalu.bdi.domain.RegisterTamuPPHPPM;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterTamuPPHPPM;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 public interface RegisterTamuPPHPPMRepository extends JpaRepository<RegisterTamuPPHPPM, Long> {
 
 	@Query("SELECT r FROM RegisterTamuPPHPPM r WHERE r.deleted=false "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterTamuPPHPPMDTO> findAllPPHPPM(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterTamuPPHPPM> findAllPPHPPM(Date startDate, Date endDate, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterTamuPPHPPM r WHERE r.deleted=false "
 			+ "AND (LOWER(r.namaPetugasPenerima) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -29,14 +27,14 @@ public interface RegisterTamuPPHPPMRepository extends JpaRepository<RegisterTamu
 			+ "OR LOWER(r.dokumenYangDisampaikan) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.tanggal DESC")
-	Page<RegisterTamuPPHPPMDTO> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
+	Page<RegisterTamuPPHPPM> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
 	
 	Optional<RegisterTamuPPHPPM> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterTamuPPHPPM r WHERE r.deleted=false "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggal DESC")
-	Page<RegisterTamuPPHPPMDTO> findAllPPHPPMtoPrint(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterTamuPPHPPM> findAllPPHPPMtoPrint(Date startDate, Date endDate, Pageable pageable);
 	
 	@Query("SELECT "
 			+ "(SELECT COUNT(r.jenisPelayanan) r FROM RegisterTamuPPHPPM r WHERE r.jenisPelayanan = 'PPH' "

--- a/src/main/java/id/go/kejaripalu/bdi/repository/RegisterTelaahanIntelijenRepository.java
+++ b/src/main/java/id/go/kejaripalu/bdi/repository/RegisterTelaahanIntelijenRepository.java
@@ -1,22 +1,20 @@
 package id.go.kejaripalu.bdi.repository;
 
-import java.util.Date;
-import java.util.Optional;
-
-import id.go.kejaripalu.bdi.dto.RegisterTelaahanIntelijenDTO;
+import id.go.kejaripalu.bdi.domain.RegisterTelaahanIntelijen;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import id.go.kejaripalu.bdi.domain.RegisterTelaahanIntelijen;
+import java.util.Date;
+import java.util.Optional;
 
 public interface RegisterTelaahanIntelijenRepository extends JpaRepository<RegisterTelaahanIntelijen, Long> {
 
 	@Query("SELECT r FROM RegisterTelaahanIntelijen r WHERE r.deleted=false "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC")
-	Page<RegisterTelaahanIntelijenDTO> findAllLahin(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterTelaahanIntelijen> findAllLahin(Date startDate, Date endDate, Pageable pageable);
 	
 	@Query("SELECT r FROM RegisterTelaahanIntelijen r WHERE r.deleted=false "
 			+ "AND (LOWER(r.nomor) LIKE LOWER(CONCAT('%', :value, '%')) "
@@ -24,13 +22,13 @@ public interface RegisterTelaahanIntelijenRepository extends JpaRepository<Regis
 			+ "OR LOWER(r.perihal) LIKE LOWER(CONCAT('%', :value, '%')) "
 			+ "OR LOWER(r.tindakLanjut) LIKE LOWER(CONCAT('%', :value, '%'))) "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate ORDER BY r.tanggal  DESC")
-	Page<RegisterTelaahanIntelijenDTO> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
+	Page<RegisterTelaahanIntelijen> findBySearching(Date startDate, Date endDate, String value, Pageable pageable);
 	
 	Optional<RegisterTelaahanIntelijen> findByIdsAndDeletedFalse(String ids);
 	
 	@Query("SELECT r FROM RegisterTelaahanIntelijen r WHERE r.deleted=false "
 			+ "AND r.tanggal BETWEEN :startDate AND :endDate "
 			+ "ORDER BY r.id DESC, r.tanggal  DESC")
-	Page<RegisterTelaahanIntelijenDTO> findAllLahinToPrint(Date startDate, Date endDate, Pageable pageable);
+	Page<RegisterTelaahanIntelijen> findAllLahinToPrint(Date startDate, Date endDate, Pageable pageable);
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/DataPetaServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/DataPetaServiceImpl.java
@@ -35,7 +35,8 @@ public class DataPetaServiceImpl implements DataPetaService {
         Date end = ParserDateUtil.end(endDate);
         Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findAll(start, end, bidangDirektorat, pageRequest);
+        return repository.findAll(start, end, bidangDirektorat, pageRequest)
+                .map(DataPetaMapper.INSTANCE::toDTO);
     }
 
     @Override
@@ -52,7 +53,8 @@ public class DataPetaServiceImpl implements DataPetaService {
         Date end = ParserDateUtil.end(endDate);
         Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findBySearching(start, end, bidangDirektorat, value, pageRequest);
+        return repository.findBySearching(start, end, bidangDirektorat, value, pageRequest)
+                .map(DataPetaMapper.INSTANCE::toDTO);
     }
 
     @Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterArsipServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterArsipServiceImpl.java
@@ -64,31 +64,32 @@ public class RegisterArsipServiceImpl implements RegisterArsipService {
 	@Override
 	@Transactional
 	public Page<RegisterArsipDTO> findAll(String start, String end, Integer pages, Integer sizes) {
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-		
+
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return arsipRepository.findAllArsip(
-                startDate, endDate, pageRequest);
+		return arsipRepository.findAllArsip(startDate, endDate, pageRequest)
+				.map(RegisterArsipMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterArsipDTO> findBySearching(
-			String start, String end, String value, Integer pages, Integer sizes) {
-        log.info("Value : {}", value);
+	public Page<RegisterArsipDTO> findBySearching(String start, String end, String value, Integer pages,
+			Integer sizes) {
+
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
 			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-		
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
-        return arsipRepository.findBySearching(
-                startDate, endDate, value, pageRequest);
+
+		return arsipRepository.findBySearching(startDate, endDate, value, pageRequest)
+				.map(RegisterArsipMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterEkspedisiServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterEkspedisiServiceImpl.java
@@ -73,12 +73,12 @@ public class RegisterEkspedisiServiceImpl implements RegisterEkspedisiService {
 			jenisSurat = JenisSurat.RAHASIA;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		
 		Pageable pageRequest = PageRequest.of(pages, sizes);
-        return ekspedisiRepository.findEkspedisiAll(
-                startDate, endDate, jenisSurat, pageRequest);
+		return ekspedisiRepository.findEkspedisiAll(startDate, endDate, jenisSurat, pageRequest)
+				.map(RegisterEkspedisiMapper.INSTANCE::toDTO);
 	}
 	
 	@Override
@@ -103,24 +103,25 @@ public class RegisterEkspedisiServiceImpl implements RegisterEkspedisiService {
 
 	@Override
 	@Transactional
-	public Page<RegisterEkspedisiDTO> findBySearching(
-			String start, String end, String value, String stringJenisSurat, Integer pages, Integer sizes) {
+	public Page<RegisterEkspedisiDTO> findBySearching(String start, String end, String stringJenisSurat, String value,
+			Integer pages, Integer sizes) {
 		JenisSurat jenisSurat = JenisSurat.BIASA;
 		if (stringJenisSurat.equals("RAHASIA")) {
 			jenisSurat = JenisSurat.RAHASIA;
 		}
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-		
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
-        return ekspedisiRepository.findEkspedisiBySearching(
-                startDate, endDate, value, jenisSurat, pageRequest);
+
+		return ekspedisiRepository.findEkspedisiBySearching(startDate, endDate, value, jenisSurat, pageRequest)
+				.map(RegisterEkspedisiMapper.INSTANCE::toDTO);
 	}
 	
 }

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKegiatanIntelijenPamstraServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKegiatanIntelijenPamstraServiceImpl.java
@@ -77,30 +77,30 @@ public class RegisterKegiatanIntelijenPamstraServiceImpl implements RegisterKegi
 	@Override
 	@Transactional
 	public Page<RegisterKegiatanIntelijenPamstraDTO> findAll(String start, String end, Integer pages, Integer sizes) {
-
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findAllKegiatan(startDate, endDate, pageRequest);
+		return repository.findAllKegiatan(startDate, endDate, pageRequest)
+				.map(RegisterKegiatanIntelijenPamstraMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterKegiatanIntelijenPamstraDTO> findBySearching(String start, String end, String value, Integer pages,
-			Integer sizes) {
-
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+	public Page<RegisterKegiatanIntelijenPamstraDTO> findBySearching(String start, String end, String value,
+			Integer pages, Integer sizes) {
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findBySearching(startDate, endDate, value, pageRequest);
+		return repository.findBySearching(startDate, endDate, value, pageRequest)
+				.map(RegisterKegiatanIntelijenPamstraMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKegiatanIntelijenServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKegiatanIntelijenServiceImpl.java
@@ -71,7 +71,8 @@ public class RegisterKegiatanIntelijenServiceImpl implements RegisterKegiatanInt
         Pageable pageRequest = PageRequest.of(pages, sizes);
 
         return repository.findAllKegiatan(
-                startDate, endDate, bidangDirektorat, pageRequest);
+                startDate, endDate, bidangDirektorat, pageRequest)
+				.map(RegisterKegiatanIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override
@@ -91,7 +92,8 @@ public class RegisterKegiatanIntelijenServiceImpl implements RegisterKegiatanInt
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
         return repository.findBySearching(
-                startDate, endDate, bidangDirektorat, value, pageRequest);
+                startDate, endDate, bidangDirektorat, value, pageRequest)
+				.map(RegisterKegiatanIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKerjaIntelijenServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterKerjaIntelijenServiceImpl.java
@@ -74,15 +74,37 @@ public class RegisterKerjaIntelijenServiceImpl implements RegisterKerjaIntelijen
 
 	@Override
 	@Transactional
-	public Page<RegisterKerjaIntelijenDTO> findAll(
-            String start, String end, String stringBidangDirektorat, Integer pages, Integer sizes) {
-
+	public Page<RegisterKerjaIntelijenDTO> findAll(String start, String end, String stringBidangDirektorat,
+			Integer pages, Integer sizes) {
 		BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-        Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return rkiRepository.findRKIAll(startDate, endDate, bidangDirektorat, pageRequest);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
+
+		return rkiRepository.findRKIAll(startDate, endDate, bidangDirektorat, pageRequest)
+				.map(RegisterKerjaIntelijenMapper.INSTANCE::toDTO);
+	}
+
+	@Override
+	@Transactional
+	public Page<RegisterKerjaIntelijenDTO> findBySearching(String start, String end, String stringBidangDirektorat,
+			String value, Integer pages,
+			Integer sizes) {
+		BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
+
+		log.info("🔍 Value for searching: {}", value);
+		if (value.isBlank()) {
+			log.error("💀 Isi text pencarian kosong...");
+			return null;
+		}
+
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
+
+		return rkiRepository.findRKIBySearching(startDate, endDate, value, bidangDirektorat, pageRequest)
+				.map(RegisterKerjaIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override
@@ -94,26 +116,6 @@ public class RegisterKerjaIntelijenServiceImpl implements RegisterKerjaIntelijen
 		rki.setUraianPeristiwaMasalah(rki.getIds() + " | " + rki.getUraianPeristiwaMasalah());
 		rkiRepository.save(rki);
         log.info("✔️ Soft Delete Successfully!!! ദ്ദി(ᵔᗜᵔ): {}", rki);
-	}
-
-	@Override
-	@Transactional
-	public Page<RegisterKerjaIntelijenDTO> findBySearching(String start, String end, String value, String stringBidangDirektorat,
-                                                           Integer pages, Integer sizes) {
-
-		log.info("\uD83D\uDD0E Value for searching: {}", value);
-		if (value.isBlank()) {
-			log.error("💀 Isi text pencarian kosong...");
-			return null;
-		}
-
-		BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-		Pageable pageRequest = PageRequest.of(pages, sizes);
-
-        return rkiRepository.findRKIBySearching(
-                startDate, endDate, value, bidangDirektorat, pageRequest);
 	}
 
 }

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterOperasiIntelijenServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterOperasiIntelijenServiceImpl.java
@@ -64,35 +64,37 @@ public class RegisterOperasiIntelijenServiceImpl implements RegisterOperasiIntel
 
 	@Override
 	@Transactional
-	public Page<RegisterOperasiIntelijenDTO> findAll(String start, String end, String stringBidangDirektorat,
-			Integer pages, Integer sizes) {
+	public Page<RegisterOperasiIntelijenDTO> findAll(String start, String end, String stringBidangDirektorat, Integer pages, Integer sizes) {
+		BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
 
-        BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
-		Date startDate = ParserDateUtil.start(start);
-		Date endDate = ParserDateUtil.end(end);
-		Pageable pageRequest = PageRequest.of(pages, sizes);
+        Date startDate = ParserDateUtil.start(start);
+        Date endDate = ParserDateUtil.end(end);
+        Pageable pageRequest = PageRequest.of(pages, sizes);
 
         return repository.findAllOpsin(
-                startDate, endDate, bidangDirektorat, pageRequest);
+                startDate, endDate, bidangDirektorat, pageRequest)
+				.map(RegisterOperasiIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterOperasiIntelijenDTO> findBySearching(String start, String end, String stringBidangDirektorat, String value, Integer pages, Integer sizes) {
+	public Page<RegisterOperasiIntelijenDTO> findBySearching(String start, String end, String stringBidangDirektorat, String value, Integer pages,
+			Integer sizes) {
+		BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
 
-        log.info("\uD83D\uDD0E Value : {}", value);
+        log.info("\uD83D\uDD0E Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        BidangDirektorat bidangDirektorat = GetBidangDirektorat.get(stringBidangDirektorat);
         Date startDate = ParserDateUtil.start(start);
         Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
         return repository.findBySearching(
-                startDate, endDate, bidangDirektorat, value, pageRequest);
+                startDate, endDate, bidangDirektorat, value, pageRequest)
+				.map(RegisterOperasiIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterPenkumLuhkumServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterPenkumLuhkumServiceImpl.java
@@ -70,36 +70,36 @@ public class RegisterPenkumLuhkumServiceImpl implements RegisterPenkumLuhkumServ
 
 	@Override
 	@Transactional
-	public Page<RegisterPenkumLuhkumDTO> findAll(String start, String end, String stringJenisKegiatan,
-			Integer pages, Integer sizes) {
-		
+	public Page<RegisterPenkumLuhkumDTO> findAll(String start, String end, String stringJenisKegiatan, Integer pages,
+			Integer sizes) {
 		JenisKegiatanPenkumLuhkum jenisKegiatan = getJenisKegiatan(stringJenisKegiatan);
+
 		Date startDate = ParserDateUtil.start(start);
 		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findAllPenkumLuhkum(
-                startDate, endDate, jenisKegiatan, pageRequest);
+		return repository.findAllPenkumLuhkum(startDate, endDate, jenisKegiatan, pageRequest)
+				.map(RegisterPenkumLuhkumMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterPenkumLuhkumDTO> findBySearching(String start, String end,
-			String stringJenisKegiatan, String value, Integer pages, Integer sizes) {
+	public Page<RegisterPenkumLuhkumDTO> findBySearching(String start, String end, String stringJenisKegiatan,
+			String value, Integer pages, Integer sizes) {
+		JenisKegiatanPenkumLuhkum jenisKegiatan = getJenisKegiatan(stringJenisKegiatan);
 
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
 			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-		JenisKegiatanPenkumLuhkum jenisKegiatan = getJenisKegiatan(stringJenisKegiatan);
 		Date startDate = ParserDateUtil.start(start);
 		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findBySearching(
-                startDate, endDate, jenisKegiatan, value, pageRequest);
+		return repository.findBySearching(startDate, endDate, jenisKegiatan, value, pageRequest)
+				.map(RegisterPenkumLuhkumMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterProdukIntelijenServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterProdukIntelijenServiceImpl.java
@@ -62,31 +62,29 @@ public class RegisterProdukIntelijenServiceImpl implements RegisterProdukIntelij
     @Override
     @Transactional
     public Page<RegisterProdukIntelijenDTO> findAll(String start, String end, Integer pages, Integer sizes) {
-
         Date startDate = ParserDateUtil.start(start);
         Date endDate = ParserDateUtil.end(end);
         Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return produkIntelijenRepository.findProdukIntelijenAll(
-                startDate, endDate, pageRequest);
+        return produkIntelijenRepository.findProdukIntelijenAll(startDate, endDate, pageRequest)
+                .map(RegisterProdukIntelijenMapper.INSTANCE::toDTO);
     }
 
     @Override
     @Transactional
     public Page<RegisterProdukIntelijenDTO> findBySearching(String start, String end, String value, Integer pages, Integer sizes) {
-
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+        log.info("🔍 Value for searching: {}", value);
         if (value.isBlank()) {
-        	log.warn("💀 Isi text pencarian kosong...");
-			return null;
+            log.error("💀 Isi text pencarian kosong...");
+            return null;
         }
 
         Date startDate = ParserDateUtil.start(start);
         Date endDate = ParserDateUtil.end(end);
         Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return produkIntelijenRepository.findProdukIntelijenBySearching(
-                startDate, endDate, value, pageRequest);
+        return produkIntelijenRepository.findProdukIntelijenBySearching(startDate, endDate, value, pageRequest)
+                .map(RegisterProdukIntelijenMapper.INSTANCE::toDTO);
     }
 
     @Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterSuratKeluarServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterSuratKeluarServiceImpl.java
@@ -29,23 +29,6 @@ public class RegisterSuratKeluarServiceImpl implements RegisterSuratService<Regi
 
 	@Override
 	@Transactional
-	public Page<RegisterSuratKeluarDTO> findAll(String startDate, String endDate, String stringJenisSurat,
-											   Integer pages, Integer sizes) {
-
-        JenisSurat jenisSurat = JenisSurat.BIASA;
-		if (stringJenisSurat.equals("RAHASIA")) {
-			jenisSurat = JenisSurat.RAHASIA;
-		}
-
-        Date start = ParserDateUtil.start(startDate);
-        Date end = ParserDateUtil.end(endDate);
-        Pageable pageRequest = PageRequest.of(pages, sizes);
-
-        return suratKeluarRepository.findSuratKeluar(start, end, jenisSurat, pageRequest);
-	}
-
-	@Override
-	@Transactional
 	public RegisterSuratKeluarDTO create(RegisterSuratKeluarDTO request) {
 		RegisterSuratKeluarDTO suratKeluar =
 				RegisterSuratKeluarMapper.INSTANCE.toDTO(
@@ -99,24 +82,41 @@ public class RegisterSuratKeluarServiceImpl implements RegisterSuratService<Regi
 
 	@Override
 	@Transactional
-	public Page<RegisterSuratKeluarDTO> findBySearching(String start, String end, String value,
-			String stringJenisSurat, Integer pages, Integer sizes) {
-
+	public Page<RegisterSuratKeluarDTO> findAll(String start, String end, String stringJenisSurat, Integer pages,
+			Integer sizes) {
 		JenisSurat jenisSurat = JenisSurat.BIASA;
 		if (stringJenisSurat.equals("RAHASIA")) {
 			jenisSurat = JenisSurat.RAHASIA;
 		}
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
+
+		return suratKeluarRepository.findSuratKeluar(startDate, endDate, jenisSurat, pageRequest)
+				.map(RegisterSuratKeluarMapper.INSTANCE::toDTO);
+	}
+
+	@Override
+	@Transactional
+	public Page<RegisterSuratKeluarDTO> findBySearching(String start, String end, String stringJenisSurat, String value,
+			Integer pages, Integer sizes) {
+		JenisSurat jenisSurat = JenisSurat.BIASA;
+		if (stringJenisSurat.equals("RAHASIA")) {
+			jenisSurat = JenisSurat.RAHASIA;
+		}
+
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-        Pageable pageRequest = PageRequest.of(pages, sizes);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return suratKeluarRepository.findSuratKeluarBySearch(
-                startDate, endDate, value, jenisSurat, pageRequest);
+		return suratKeluarRepository.findSuratKeluarBySearch(startDate, endDate, value, jenisSurat, pageRequest)
+				.map(RegisterSuratKeluarMapper.INSTANCE::toDTO);
 	}
 }

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterSuratMasukServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterSuratMasukServiceImpl.java
@@ -25,40 +25,40 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RegisterSuratMasukServiceImpl implements RegisterSuratService<RegisterSuratMasukDTO> {
 
-	private final RegisterSuratMasukRepository suratMasukRepository;
-
+	private final RegisterSuratMasukRepository repository;
+	
 	@Override
 	@Transactional
-	public RegisterSuratMasukDTO create(RegisterSuratMasukDTO suratMasukDTO) {
+	public RegisterSuratMasukDTO create(RegisterSuratMasukDTO request) {
+
 		RegisterSuratMasukDTO suratMasuk =
                 RegisterSuratMasukMapper.INSTANCE.toDTO(
-						Objects.requireNonNull(suratMasukRepository.save(
-								Objects.requireNonNull(RegisterSuratMasukMapper.INSTANCE.toEntity(suratMasukDTO)))));
+                        Objects.requireNonNull(repository.save(
+                                Objects.requireNonNull(RegisterSuratMasukMapper.INSTANCE.toEntity(request)))));
 
-		log.info("✔️ Successfully saved!!! ദ്ദി(ᵔᗜᵔ)  Surat Masuk!!!");
+        log.info("✔️ Successfully saved!!! ദ്ദി(ᵔᗜᵔ) Surat Masuk!!!");
         return suratMasuk;
 	}
 
 	@Override
 	@Transactional
-	public RegisterSuratMasukDTO update(String ids, RegisterSuratMasukDTO suratMasukDTO) {
-		RegisterSuratMasuk suratMasuk = suratMasukRepository.findByIdsAndDeletedFalse(ids)
+	public RegisterSuratMasukDTO update(String ids, RegisterSuratMasukDTO request) {
+		RegisterSuratMasuk suratMasuk = repository.findByIdsAndDeletedFalse(ids)
 				.orElseThrow(() -> new NotFoundException("ID_NOT_FOUND"));
-		suratMasuk.setTanggalPenerimaanSurat(suratMasukDTO.tanggalPenerimaanSurat());
-		suratMasuk.setJamPenerimaanSurat(suratMasukDTO.jamPenerimaanSurat());
-		suratMasuk.setAsal(suratMasukDTO.asal());
-		suratMasuk.setPerihal(suratMasukDTO.perihal());
-		suratMasuk.setTanggalSurat(suratMasukDTO.tanggalSurat());
-		suratMasuk.setNomorSurat(suratMasukDTO.nomorSurat());
-		suratMasuk.setJenisSurat(suratMasukDTO.jenisSurat());
-		suratMasuk.setIsiDisposisi(suratMasukDTO.isiDisposisi());
-		suratMasuk.setTindakLanjutDisposisi(suratMasukDTO.tindakLanjutDisposisi());
-		suratMasuk.setKeterangan(suratMasukDTO.keterangan());
-		suratMasuk.setUrlFile(suratMasukDTO.urlFile());
-		
+		suratMasuk.setTanggalPenerimaanSurat(request.tanggalPenerimaanSurat());
+		suratMasuk.setJamPenerimaanSurat(request.jamPenerimaanSurat());
+		suratMasuk.setNomorSurat(request.nomorSurat());
+		suratMasuk.setTanggalSurat(request.tanggalSurat());
+		suratMasuk.setAsal(request.asal());
+		suratMasuk.setPerihal(request.perihal());
+		suratMasuk.setIsiDisposisi(request.isiDisposisi());
+		suratMasuk.setTindakLanjutDisposisi(request.tindakLanjutDisposisi());
+		suratMasuk.setKeterangan(request.keterangan());
+		suratMasuk.setUrlFile(request.urlFile());
+		suratMasuk.setJenisSurat(request.jenisSurat());
+
 		RegisterSuratMasukDTO registerSuratMasukDTO =
-                RegisterSuratMasukMapper.INSTANCE.toDTO(
-						Objects.requireNonNull(suratMasukRepository.save(suratMasuk)));
+                RegisterSuratMasukMapper.INSTANCE.toDTO(Objects.requireNonNull(repository.save(suratMasuk)));
 
         log.info("✔️ Successfully updated!!! ദ്ദി(ᵔᗜᵔ) Surat Masuk!!!");
         return registerSuratMasukDTO;
@@ -66,60 +66,61 @@ public class RegisterSuratMasukServiceImpl implements RegisterSuratService<Regis
 
 	@Override
 	@Transactional
-	public Page<RegisterSuratMasukDTO> findAll(String start, String end, String stringJenisSurat,
-											   Integer pages, Integer sizes) {
-        JenisSurat jenisSurat = JenisSurat.BIASA;
-        if (stringJenisSurat.equals("RAHASIA")) {
-            jenisSurat = JenisSurat.RAHASIA;
-        }
-
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-        Pageable pageRequest = PageRequest.of(pages, sizes);
-
-        return suratMasukRepository.findSuratMasukAll(
-                startDate, endDate, jenisSurat, pageRequest);
-    }
-
-	@Override
-	@Transactional
 	public RegisterSuratMasukDTO findByIds(String ids) {
-		RegisterSuratMasuk suratMasuk = suratMasukRepository.findByIdsAndDeletedFalse(ids)
+		RegisterSuratMasuk suratMasuk = repository.findByIdsAndDeletedFalse(ids)
 				.orElseThrow(() -> new NotFoundException("ID_NOT_FOUND"));
-
-        return RegisterSuratMasukMapper.INSTANCE.toDTO(suratMasuk);
+		
+		return RegisterSuratMasukMapper.INSTANCE.toDTO(suratMasuk);
 	}
 
 	@Override
 	@Transactional
 	public void delete(String ids) {
-		RegisterSuratMasuk suratMasuk = suratMasukRepository.findByIdsAndDeletedFalse(ids)
+		RegisterSuratMasuk suratMasuk = repository.findByIdsAndDeletedFalse(ids)
 				.orElseThrow(() -> new NotFoundException("ID_NOT_FOUND"));
 		suratMasuk.setDeleted(true);
 		suratMasuk.setNomorSurat(suratMasuk.getIds() + " | " + suratMasuk.getNomorSurat());
-		suratMasukRepository.save(suratMasuk);
-		log.info("✔️ Soft Delete Successfully!!! ദ്ദി(ᵔᗜᵔ): Surat Masuk!!!");
+		repository.save(suratMasuk);
+		log.info("✔️ Soft Delete Successfully!!! ദ്ദി(ᵔᗜᵔ) Surat Masuk!!!");
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterSuratMasukDTO> findBySearching(
-			String start, String end, String value, String stringJenisSurat, Integer pages, Integer sizes) {
+	public Page<RegisterSuratMasukDTO> findAll(String start, String end, String stringJenisSurat, Integer pages,
+			Integer sizes) {
 		JenisSurat jenisSurat = JenisSurat.BIASA;
 		if (stringJenisSurat.equals("RAHASIA")) {
 			jenisSurat = JenisSurat.RAHASIA;
 		}
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
+
+		return repository.findSuratMasukAll(startDate, endDate, jenisSurat, pageRequest)
+				.map(RegisterSuratMasukMapper.INSTANCE::toDTO);
+	}
+
+	@Override
+	@Transactional
+	public Page<RegisterSuratMasukDTO> findBySearching(String start, String end, String stringJenisSurat, String value,
+			Integer pages, Integer sizes) {
+		JenisSurat jenisSurat = JenisSurat.BIASA;
+		if (stringJenisSurat.equals("RAHASIA")) {
+			jenisSurat = JenisSurat.RAHASIA;
+		}
+
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date startDate = ParserDateUtil.start(start);
-        Date endDate = ParserDateUtil.end(end);
-        Pageable pageRequest = PageRequest.of(pages, sizes);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return suratMasukRepository.findSuratMasukBySearching(
-                startDate, endDate, value, jenisSurat, pageRequest);
+		return repository.findSuratMasukBySearching(startDate, endDate, value, jenisSurat, pageRequest)
+				.map(RegisterSuratMasukMapper.INSTANCE::toDTO);
 	}
 }

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterTamuPPHPPMServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterTamuPPHPPMServiceImpl.java
@@ -73,31 +73,31 @@ public class RegisterTamuPPHPPMServiceImpl implements RegisterTamuPPHPPMService 
 
 	@Override
 	@Transactional
-	public Page<RegisterTamuPPHPPMDTO> findAll(String startDate, String endDate, Integer pages, Integer sizes) {
+	public Page<RegisterTamuPPHPPMDTO> findAll(String start, String end, Integer pages, Integer sizes) {
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        Date start = ParserDateUtil.start(startDate);
-        Date end = ParserDateUtil.end(endDate);
-        Pageable pageable = PageRequest.of(pages, sizes);
-
-        return repository.findAllPPHPPM(start, end, pageable);
+		return repository.findAllPPHPPM(startDate, endDate, pageRequest)
+				.map(RegisterTamuPPHPPMMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
-	public Page<RegisterTamuPPHPPMDTO> findBySearching(String startDate, String endDate, String value,
-                                                    Integer pages, Integer sizes) {
-
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+	public Page<RegisterTamuPPHPPMDTO> findBySearching(String start, String end, String value, Integer pages,
+			Integer sizes) {
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
-			log.warn("💀 Isi text pencarian kosong...");
+			log.error("💀 Isi text pencarian kosong...");
 			return null;
 		}
 
-        Date start = ParserDateUtil.start(startDate);
-        Date end = ParserDateUtil.end(endDate);
-        Pageable pageable = PageRequest.of(pages, sizes);
+		Date startDate = ParserDateUtil.start(start);
+		Date endDate = ParserDateUtil.end(end);
+		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findBySearching(start, end, value, pageable);
+		return repository.findBySearching(startDate, endDate, value, pageRequest)
+				.map(RegisterTamuPPHPPMMapper.INSTANCE::toDTO);
 	}
 
 	@Override

--- a/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterTelaahanIntelijenServiceImpl.java
+++ b/src/main/java/id/go/kejaripalu/bdi/service/impl/RegisterTelaahanIntelijenServiceImpl.java
@@ -64,21 +64,19 @@ public class RegisterTelaahanIntelijenServiceImpl implements RegisterTelaahanInt
 	@Override
 	@Transactional
 	public Page<RegisterTelaahanIntelijenDTO> findAll(String start, String end, Integer pages, Integer sizes) {
-
 		Date startDate = ParserDateUtil.start(start);
 		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findAllLahin(
-                startDate, endDate, pageRequest);
+		return repository.findAllLahin(startDate, endDate, pageRequest)
+				.map(RegisterTelaahanIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override
 	@Transactional
 	public Page<RegisterTelaahanIntelijenDTO> findBySearching(String start, String end, String value, Integer pages,
 			Integer sizes) {
-
-        log.info("\uD83D\uDD0E Value for searching: {}", value);
+		log.info("🔍 Value for searching: {}", value);
 		if (value.isBlank()) {
 			log.error("💀 Isi text pencarian kosong...");
 			return null;
@@ -88,8 +86,8 @@ public class RegisterTelaahanIntelijenServiceImpl implements RegisterTelaahanInt
 		Date endDate = ParserDateUtil.end(end);
 		Pageable pageRequest = PageRequest.of(pages, sizes);
 
-        return repository.findBySearching(
-                startDate, endDate, value, pageRequest);
+		return repository.findBySearching(startDate, endDate, value, pageRequest)
+				.map(RegisterTelaahanIntelijenMapper.INSTANCE::toDTO);
 	}
 
 	@Override


### PR DESCRIPTION
This PR resolves the ConverterNotFoundException across 13 modules by ensuring JPA Repositories return Entities instead of DTOs, moving the mapping logic to the Service layer.

### Changes:
- Updated all 13 Repository interfaces to return Page<Entity>.
- Moved mapping logic to the Service layer using MapStruct.
- Updated README.md to document the architecture pattern.

Closes #10